### PR TITLE
solr_search: automatic adjusting of maxRows

### DIFF
--- a/R/solr_search.r
+++ b/R/solr_search.r
@@ -109,6 +109,26 @@
 solr_search <- function(name = NULL, q='*:*', sort=NULL, start=NULL, rows=NULL, pageDoc=NULL,
   pageScore=NULL, fq=NULL, fl=NULL, defType=NULL, timeAllowed=NULL, qt=NULL,
   wt='json', NOW=NULL, TZ=NULL, echoHandler=NULL, echoParams=NULL, key = NULL,
+  callopts=list(), raw=FALSE, parsetype='df', concat=',',
+  optimizeMaxRows=TRUE, minOptimizedRows=50000, ...) {
+
+  if (!is.null(rows) & (optimizeMaxRows)) {
+    if (rows>minOptimizedRows) {
+      out <- solr_search_exec(name=name, q=q, rows='0', wt='json', raw='TRUE')
+      outJson <- fromJSON(out)
+      rows <- outJson$response$numFound
+    }
+  }
+
+  solr_search_exec(name, q, sort, start, rows, pageDoc,
+    pageScore, fq, fl, defType, timeAllowed,
+    qt, wt, NOW, TZ, echoHandler, echoParams,
+    key, callopts, raw, parsetype, concat, ...)
+}
+
+solr_search_exec <- function(name = NULL, q='*:*', sort=NULL, start=NULL, rows=NULL, pageDoc=NULL,
+  pageScore=NULL, fq=NULL, fl=NULL, defType=NULL, timeAllowed=NULL, qt=NULL,
+  wt='json', NOW=NULL, TZ=NULL, echoHandler=NULL, echoParams=NULL, key = NULL,
   callopts=list(), raw=FALSE, parsetype='df', concat=',', ...) {
 
   check_defunct(...)

--- a/R/solr_search.r
+++ b/R/solr_search.r
@@ -22,6 +22,9 @@
 #' # search
 #' solr_search(q='*:*', rows=2, fl='id')
 #'
+#' # search and return all rows
+#' solr_search(q='*:*', rows=-1, fl='id')
+#'
 #' # Search for word ecology in title and cell in the body
 #' solr_search(q='title:"ecology" AND body:"cell"', fl='title', rows=5)
 #'
@@ -108,15 +111,15 @@
 
 solr_search <- function(name = NULL, q='*:*', sort=NULL, start=NULL, rows=NULL, pageDoc=NULL,
   pageScore=NULL, fq=NULL, fl=NULL, defType=NULL, timeAllowed=NULL, qt=NULL,
-  wt='json', NOW=NULL, TZ=NULL, echoHandler=NULL, echoParams=NULL, key = NULL,
+  wt='json', NOW=NULL, TZ=NULL, echoHandler=NULL, echoParams=NULL, key=NULL,
   callopts=list(), raw=FALSE, parsetype='df', concat=',',
   optimizeMaxRows=TRUE, minOptimizedRows=50000, ...) {
 
-  if (!is.null(rows) & (optimizeMaxRows)) {
-    if (rows>minOptimizedRows) {
+  if (!is.null(rows) && optimizeMaxRows) {
+    if (rows > minOptimizedRows || rows < 0) {
       out <- solr_search_exec(name=name, q=q, rows='0', wt='json', raw='TRUE')
       outJson <- fromJSON(out)
-      rows <- outJson$response$numFound
+      if (rows > outJson$response$numFound || rows < 0) rows <- outJson$response$numFound
     }
   }
 

--- a/R/solr_search.r
+++ b/R/solr_search.r
@@ -119,7 +119,7 @@ solr_search <- function(name = NULL, q='*:*', sort=NULL, start=NULL, rows=NULL, 
     if (rows > minOptimizedRows || rows < 0) {
       out <- solr_search_exec(name=name, q=q, rows='0', wt='json', raw='TRUE')
       outJson <- fromJSON(out)
-      if (rows > outJson$response$numFound || rows < 0) rows <- outJson$response$numFound
+      if (rows > outJson$response$numFound || rows < 0) rows <- as.double(outJson$response$numFound)
     }
   }
 

--- a/man-roxygen/search.r
+++ b/man-roxygen/search.r
@@ -47,4 +47,9 @@
 #' @param concat (character) Character to concatenate elements of longer than length 1. 
 #' Note that this only works reliably when data format is json (wt='json'). The parsing
 #' is more complicated in XML format, but you can do that on your own.
+#' @param optimizeMaxRows (logical) If TRUE, then rows parameter will be adjusted to the number of returned
+#' results by the same constraints. It will only be applied if rows parameter is higher
+#' than minOptimizedRows. Default: TRUE
+#' @param minOptimizedRows minOptimizedRows parameter is used by optimizedMaxRows parameter.
+#' Default: 50000
 #' @param ... Further args.

--- a/man/solr_search.Rd
+++ b/man/solr_search.Rd
@@ -9,7 +9,7 @@ solr_search(name = NULL, q = "*:*", sort = NULL, start = NULL,
   defType = NULL, timeAllowed = NULL, qt = NULL, wt = "json",
   NOW = NULL, TZ = NULL, echoHandler = NULL, echoParams = NULL,
   key = NULL, callopts = list(), raw = FALSE, parsetype = "df",
-  concat = ",", ...)
+  concat = ",", optimizeMaxRows = TRUE, minOptimizedRows = 50000, ...)
 }
 \arguments{
 \item{name}{Name of a collection or core. Or leave as \code{NULL} if not needed.}
@@ -87,6 +87,13 @@ include:
 \item{concat}{(character) Character to concatenate elements of longer than length 1. 
 Note that this only works reliably when data format is json (wt='json'). The parsing
 is more complicated in XML format, but you can do that on your own.}
+
+\item{optimizeMaxRows}{(logical) If TRUE, then rows parameter will be adjusted to the number of returned
+results by the same constraints. It will only be applied if rows parameter is higher
+than minOptimizedRows. Default: TRUE}
+
+\item{minOptimizedRows}{minOptimizedRows parameter is used by optimizedMaxRows parameter.
+Default: 50000}
 
 \item{...}{Further args.}
 }
@@ -199,4 +206,3 @@ See \url{http://wiki.apache.org/solr/#Search_and_Indexing} for more information.
 \seealso{
 \code{\link{solr_highlight}}, \code{\link{solr_facet}}
 }
-

--- a/tests/testthat/test-solr_search.r
+++ b/tests/testthat/test-solr_search.r
@@ -99,45 +99,60 @@ test_that("solr_search works with Dryad", {
   expect_true(all(grepl("ecolog", b$dc.title.en, ignore.case = TRUE)))
 })
 
-test_that("solr_search optimize max rows with rows -1", {
+test_that("solr_search optimize max rows with lower boundary", {
   skip_on_cran()
 
   solr_connect('http://api.plos.org/search', verbose = FALSE)
 
   a <- solr_search(q='*:*', rows=1, fl='id')
   query <- paste0('id:', a$id)
-  a <- solr_search(q=query, rows=1, fl='id')
-  b <- solr_search(q=query, rows=-1, fl='id')
-  expect_identical(a, b)
+  b <- solr_search(q=query, rows=1, fl='id')
+  c <- solr_search(q=query, rows=-1, fl='id')
+
+  expect_identical(b, c)
 })
 
-test_that("solr_search optimize max rows with rows 50000", {
+test_that("solr_search optimize max rows with upper boundary", {
   skip_on_cran()
 
   solr_connect('http://api.plos.org/search', verbose = FALSE)
 
   a <- solr_search(q='*:*', rows=1, fl='id')
   query <- paste0('id:', a$id)
-  a <- solr_search(q=query, rows=1, fl='id')
-  b <- solr_search(q=query, rows=50000, fl='id')
+  b <- solr_search(q=query, rows=1, fl='id')
+  c <- solr_search(q=query, rows=50000, fl='id')
 
-  expect_identical(a, b)
+  expect_identical(b, c)
 })
 
-test_that("solr_search optimize max rows with rows 50001", {
+test_that("solr_search optimize max rows with rows higher than upper boundary", {
   skip_on_cran()
 
   solr_connect('http://api.plos.org/search', verbose = FALSE)
 
   a <- solr_search(q='*:*', rows=1, fl='id')
   query <- paste0('id:', a$id)
-  a <- solr_search(q=query, rows=1, fl='id')
-  b <- solr_search(q=query, rows=50001, fl='id')
+  b <- solr_search(q=query, rows=1, fl='id')
+  c <- solr_search(q=query, rows=50001, fl='id')
 
-  expect_identical(a, b)
+  expect_identical(b, c)
 })
 
-test_that("solr_search fails if optimize max rows is disabled with rows -1", {
+test_that("solr_search optimize max rows with rows=31 and minOptimizedRows=30", {
+  skip_on_cran()
+
+  solr_connect('http://api.plos.org/search', verbose = FALSE)
+
+  a <- solr_search(q='*:*', rows=1, fl='id')
+  query <- paste0('id:', a$id)
+  b <- solr_search(q=query, rows=1, fl='id')
+  c <- solr_search(q=query, rows=31, fl='id', optimizeMaxRows=TRUE, minOptimizedRows=30)
+
+  expect_identical(b, c)
+})
+
+
+test_that("solr_search fails if optimize max rows is disabled with rows equal to -1", {
   skip_on_cran()
 
   solr_connect('http://api.plos.org/search', verbose = FALSE)

--- a/tests/testthat/test-solr_search.r
+++ b/tests/testthat/test-solr_search.r
@@ -105,10 +105,10 @@ test_that("solr_search optimize max rows with rows -1", {
   solr_connect('http://api.plos.org/search', verbose = FALSE)
 
   a <- solr_search(q='*:*', rows=1, fl='id')
-  query <- c('id:', a$id)
+  query <- paste0('id:', a$id)
+  a <- solr_search(q=query, rows=1, fl='id')
   b <- solr_search(q=query, rows=-1, fl='id')
-
-  expect_true(identical(a, b))
+  expect_identical(a, b)
 })
 
 test_that("solr_search optimize max rows with rows 50000", {
@@ -117,10 +117,11 @@ test_that("solr_search optimize max rows with rows 50000", {
   solr_connect('http://api.plos.org/search', verbose = FALSE)
 
   a <- solr_search(q='*:*', rows=1, fl='id')
-  query <- c('id:', a$id)
+  query <- paste0('id:', a$id)
+  a <- solr_search(q=query, rows=1, fl='id')
   b <- solr_search(q=query, rows=50000, fl='id')
 
-  expect_true(identical(a, b))
+  expect_identical(a, b)
 })
 
 test_that("solr_search optimize max rows with rows 50001", {
@@ -129,10 +130,11 @@ test_that("solr_search optimize max rows with rows 50001", {
   solr_connect('http://api.plos.org/search', verbose = FALSE)
 
   a <- solr_search(q='*:*', rows=1, fl='id')
-  query <- c('id:', a$id)
+  query <- paste0('id:', a$id)
+  a <- solr_search(q=query, rows=1, fl='id')
   b <- solr_search(q=query, rows=50001, fl='id')
 
-  expect_true(identical(a, b))
+  expect_identical(a, b)
 })
 
 test_that("solr_search fails if optimize max rows is disabled with rows -1", {

--- a/tests/testthat/test-solr_search.r
+++ b/tests/testthat/test-solr_search.r
@@ -98,3 +98,49 @@ test_that("solr_search works with Dryad", {
   # correct content
   expect_true(all(grepl("ecolog", b$dc.title.en, ignore.case = TRUE)))
 })
+
+test_that("solr_search optimize max rows with rows -1", {
+  skip_on_cran()
+
+  solr_connect('http://api.plos.org/search', verbose = FALSE)
+
+  a <- solr_search(q='*:*', rows=1, fl='id')
+  query <- c('id:', a$id)
+  b <- solr_search(q=query, rows=-1, fl='id')
+
+  expect_true(identical(a, b))
+})
+
+test_that("solr_search optimize max rows with rows 50000", {
+  skip_on_cran()
+
+  solr_connect('http://api.plos.org/search', verbose = FALSE)
+
+  a <- solr_search(q='*:*', rows=1, fl='id')
+  query <- c('id:', a$id)
+  b <- solr_search(q=query, rows=50000, fl='id')
+
+  expect_true(identical(a, b))
+})
+
+test_that("solr_search optimize max rows with rows 50001", {
+  skip_on_cran()
+
+  solr_connect('http://api.plos.org/search', verbose = FALSE)
+
+  a <- solr_search(q='*:*', rows=1, fl='id')
+  query <- c('id:', a$id)
+  b <- solr_search(q=query, rows=50001, fl='id')
+
+  expect_true(identical(a, b))
+})
+
+test_that("solr_search fails if optimize max rows is disabled with rows -1", {
+  skip_on_cran()
+
+  solr_connect('http://api.plos.org/search', verbose = FALSE)
+
+  a <- solr_search(q='*:*', rows=-1, fl='id', optimizeMaxRows=FALSE)
+
+  expect_that(length(a), equals(0))
+})


### PR DESCRIPTION
There is a performance penalty when asking for too many rows.
https://wiki.apache.org/solr/SolrPerformanceProblems#Asking_for_too_many_rows

If number of rows is specified and is higher than configured limit (50000),
solr_search first queries Solr for a number of records with rows=0.
Then the initial number of rows is replaced by real number of records
and solr_search is executed.